### PR TITLE
Sets file and a stray tab

### DIFF
--- a/exponential-decay.json
+++ b/exponential-decay.json
@@ -1,0 +1,12 @@
+{
+  "edfmts": [
+    "air-application-1.0-1.5-2.0-signature-file.xml",
+    "dot-and-doc-template-97-2003-signature-file.xml",
+    "Thumbs.db-v2.0-signature-file.xml"
+  ],
+  "edconts": [
+    "air-application-container-1.0-1.5-2.0-signature-20150623.xml",
+    "bitmask-test-dot-and-doc-template-container-signature-20150410.xml",
+    "thumbs-db-container-signature-20140728.xml"
+  ]
+}

--- a/exponential-decay.json
+++ b/exponential-decay.json
@@ -2,6 +2,7 @@
   "edfmts": [
     "air-application-1.0-1.5-2.0-signature-file.xml",
     "dot-and-doc-template-97-2003-signature-file.xml",
+    "NEF-format-signatures.xml",
     "Thumbs.db-v2.0-signature-file.xml"
   ],
   "edconts": [

--- a/thumbs.db/thumbs-db-container-signature-20140728.xml
+++ b/thumbs.db/thumbs-db-container-signature-20140728.xml
@@ -13,7 +13,7 @@
 	                        <InternalSignature ID="300">
 	                            <ByteSequence Reference="BOFoffset">
 	                                <SubSequence Position="1" SubSeqMinOffset="0" SubSeqMaxOffset="0">
-	                                    <Sequence>10 00 07 00 [00:FF] 00	00 00 60 00 00 00 60 00 00 00 [00:FF] 00 00 00 01 00 00 00</Sequence>
+	                                    <Sequence>10 00 07 00 [00:FF] 00 00 00 60 00 00 00 60 00 00 00 [00:FF] 00 00 00 01 00 00 00</Sequence>
 	                                </SubSequence>
 	                            </ByteSequence>
 	                        </InternalSignature>


### PR DESCRIPTION
There is a stray tab character that breaks parsing your Thumbs container file.

Also, you can use sets files for the extend flags too. This means less typing when building with roy! Just copy that exponential-decay.json into your $SFHOME/sets directory and then...

```
roy build -extend @edfmts -extendc @edconts
```
